### PR TITLE
Fix Jimp import

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const fileUpload = require('express-fileupload');
 const path = require('path');
 const fs = require('fs');
-const Jimp = require('jimp');
+const { Jimp } = require('jimp');
 
 const app = express();
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- correct Jimp import syntax for version 1.x

## Testing
- `npm test`
- `PORT=3000 node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68478cf2d4a48331b7074a6623ba2676