### PR TITLE
Fix images 404 by serving combination directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,9 @@ const PORT = process.env.PORT || 3000;
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
+// Serve uploaded images and generated combinations
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/combinations', express.static(path.join(__dirname, 'combinations')));
 app.use(fileUpload());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Summary
- serve generated combinations and uploads directories via express static

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847966afb3c8331ad95052f6b36625e