### PR TITLE
Enhance look with thumbnails

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 body {
   font-family: 'Inter', sans-serif;
+  background-color: #f3f4f6;
+}
+
+header.bg-yellow-400 {
+  background: linear-gradient(90deg,#f9d342,#f6ad55);
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,7 +9,7 @@
 <body class="bg-gray-100 text-gray-800">
   <header class="bg-yellow-400">
     <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold">Mezcla Caritas</h1>
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -9,7 +9,7 @@
 <body class="bg-gray-100 text-gray-800">
   <header class="bg-yellow-400">
     <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold">Mezcla Caritas</h1>
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
@@ -21,10 +21,25 @@
       </div>
       <div>
         <label class="block mb-1">Foto:</label>
-        <input type="file" name="photo" accept="image/*" required class="w-full" />
+        <input id="photoInput" type="file" name="photo" accept="image/*" required class="w-full" />
       </div>
+      <img id="preview" class="w-32 h-32 object-cover rounded-full hidden" />
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Enviar</button>
     </form>
+    <script>
+      const input = document.getElementById('photoInput');
+      const preview = document.getElementById('preview');
+      input.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (ev) => {
+          preview.src = ev.target.result;
+          preview.classList.remove('hidden');
+        };
+        reader.readAsDataURL(file);
+      });
+    </script>
   </main>
 </body>
 </html>

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -9,17 +9,20 @@
 <body class="bg-gray-100 text-gray-800">
   <header class="bg-yellow-400">
     <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold">Mezcla Caritas</h1>
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
     <h2 class="text-xl font-semibold mb-4">Lobby - Ronda <%= game.round %> (Dificultad: <%= game.difficulty %>)</h2>
     <p class="mb-2">Participantes inscritos: <%= game.participants.length %></p>
-    <ul class="list-disc pl-5 mb-4">
+    <div class="grid grid-cols-3 gap-4 mb-4">
       <% game.participants.forEach(p => { %>
-        <li><%= p.name %></li>
+        <div class="flex flex-col items-center text-center">
+          <img src="/<%= p.photoPath.split('/').slice(-3).join('/') %>" alt="<%= p.name %>" class="w-16 h-16 object-cover rounded-full mb-1">
+          <span class="text-sm"><%= p.name %></span>
+        </div>
       <% }) %>
-    </ul>
+    </div>
     <a href="/join" class="text-blue-600 underline">Unirse</a>
     <form action="/start" method="post" class="mt-6">
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Comenzar ronda</button>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -9,7 +9,7 @@
 <body class="bg-gray-100 text-gray-800">
   <header class="bg-yellow-400">
     <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold">Mezcla Caritas</h1>
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -9,24 +9,30 @@
 <body class="bg-gray-100 text-gray-800">
   <header class="bg-yellow-400">
     <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold">Mezcla Caritas</h1>
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
     <h2 class="text-xl font-semibold mb-4">Tabla de posiciones - Ronda <%= game.round %></h2>
-    <table class="w-full table-auto mb-4">
-       <thead class="bg-gray-200"><tr><th class="px-2 py-1 text-left">Sesión</th><th class="px-2 py-1 text-left">Jugadores (puntos)</th><th class="px-2 py-1 text-left">Puntos totales</th></tr> </thead>
+    <table class="w-full table-auto mb-4 border-collapse">
+       <thead class="bg-gray-200">
+         <tr>
+           <th class="px-2 py-1 text-left">Sesión</th>
+           <th class="px-2 py-1 text-left">Jugadores (puntos)</th>
+           <th class="px-2 py-1 text-left">Puntos totales</th>
+         </tr>
+       </thead>
       <% sessions.forEach(s => { %>
         <tr class="border-t">
-          <td><%= s.sessionId %></td>
-          <td>
+          <td class="py-1"><%= s.sessionId %></td>
+          <td class="py-1">
             <ul>
               <% s.players.forEach(pl => { %>
                 <li><%= pl.name %> (<%= pl.points %>)</li>
               <% }) %>
             </ul>
           </td>
-          <td><%= s.points %></td>
+          <td class="py-1 font-semibold"><%= s.points %></td>
         </tr>
       <% }) %>
     </table>


### PR DESCRIPTION
## Summary
- style header and body with gradient and spacing
- show image preview on join page
- display participant thumbnails in lobby
- polish scoreboard table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479845e8b483318a52276f36b8fd7a