### PR TITLE
Switch to gpt-image-1 image API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ archivo `.env` con el siguiente contenido:
 OPENAI_API_KEY=tu_clave_aqui
 ```
 
-En la página principal puedes crear una nueva partida. Los participantes se unen subiendo su foto. El organizador inicia la ronda y se generarán imágenes combinadas. Después de adivinar se muestran los puntajes.
+En la página principal puedes crear una nueva partida. Los participantes se unen subiendo su foto. El organizador inicia la ronda y se generarán imágenes combinadas. Después de adivinar se muestran los puntajes. Para generar las combinaciones se utiliza el modelo `gpt-image-1` de OpenAI.
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. Los puntajes se agrupan por sesión en la tabla final.
 

--- a/server.js
+++ b/server.js
@@ -140,7 +140,10 @@ app.post('/start', async (req, res) => {
             type: 'object',
             properties: {
               prompt: { type: 'string' },
-              size: { type: 'string', enum: ['1024x1024', '1792x1024'] }
+              size: {
+                type: 'string',
+                enum: ['1024x1024', '1024x1536', '1536x1024']
+              }
             },
             required: ['prompt', 'size'],
             additionalProperties: false
@@ -155,18 +158,19 @@ app.post('/start', async (req, res) => {
     const dalleParams = JSON.parse(chat.choices[0].message.content);
 
     const image = await openai.images.generate({
-      model: 'dall-e-3',
+      model: 'gpt-image-1',
       prompt: dalleParams.prompt,
       n: 1,
-      size: dalleParams.size
+      size: dalleParams.size,
+      response_format: 'b64_json',
+      output_format: 'png'
     });
 
-    const responseUrl = image.data[0].url;
-    const resp = await fetch(responseUrl);
-    const buffer = await resp.arrayBuffer();
-
     const comboPath = path.join(__dirname, 'combinations', `combo_${i}.png`);
-    await fs.promises.writeFile(comboPath, Buffer.from(buffer));
+    await fs.promises.writeFile(
+      comboPath,
+      Buffer.from(image.data[0].b64_json, 'base64')
+    );
     game.combinations.push({ imagePath: comboPath, participantIds: chosen });
   }
   res.redirect('/play');


### PR DESCRIPTION
## Summary
- use the new `gpt-image-1` model when generating images
- update documentation to mention the new model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479b0443b88331b6440a175060b108