### PR TITLE
Switch to gpt-image-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ archivo `.env` con el siguiente contenido:
 OPENAI_API_KEY=tu_clave_aqui
 ```
 
+Este proyecto ahora usa el modelo `gpt-image-1` para generar las mezclas de
+fotos. El código envía las peticiones a la API de OpenAI con la opción
+`moderation` en nivel bajo. Este modelo siempre devuelve la imagen generada en
+base64, por lo que no es necesario especificar `response_format`.
+
 En la página principal puedes crear una nueva partida. Los participantes se unen subiendo su foto. El organizador inicia la ronda y se generarán imágenes combinadas. Después de adivinar se muestran los puntajes.
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. Los puntajes se agrupan por sesión en la tabla final.

--- a/server.js
+++ b/server.js
@@ -140,7 +140,10 @@ app.post('/start', async (req, res) => {
             type: 'object',
             properties: {
               prompt: { type: 'string' },
-              size: { type: 'string', enum: ['1024x1024', '1792x1024'] }
+              size: {
+                type: 'string',
+                enum: ['1024x1024', '1536x1024', '1024x1536']
+              }
             },
             required: ['prompt', 'size'],
             additionalProperties: false
@@ -155,18 +158,16 @@ app.post('/start', async (req, res) => {
     const dalleParams = JSON.parse(chat.choices[0].message.content);
 
     const image = await openai.images.generate({
-      model: 'dall-e-3',
+      model: 'gpt-image-1',
       prompt: dalleParams.prompt,
-      n: 1,
-      size: dalleParams.size
+      size: dalleParams.size,
+      moderation: 'low'
     });
 
-    const responseUrl = image.data[0].url;
-    const resp = await fetch(responseUrl);
-    const buffer = await resp.arrayBuffer();
+    const buffer = Buffer.from(image.data[0].b64_json, 'base64');
 
     const comboPath = path.join(__dirname, 'combinations', `combo_${i}.png`);
-    await fs.promises.writeFile(comboPath, Buffer.from(buffer));
+    await fs.promises.writeFile(comboPath, buffer);
     game.combinations.push({ imagePath: comboPath, participantIds: chosen });
   }
   res.redirect('/play');


### PR DESCRIPTION
## Summary
- use gpt-image-1 image generation API
- store generated images returned as base64
- mention gpt-image-1 in the README
- remove unsupported `response_format` parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68479b80a9908331a13cd97aca1c2b44