### PR TITLE
Add waiting screen and async round start

### DIFF
--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -28,5 +28,19 @@
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Comenzar ronda</button>
     </form>
   </main>
+  <script>
+    async function poll() {
+      const res = await fetch('/status');
+      const data = await res.json();
+      if (data.state === 'generating') {
+        window.location.href = '/wait';
+      } else if (data.state === 'playing') {
+        window.location.href = '/play';
+      } else {
+        setTimeout(poll, 2000);
+      }
+    }
+    poll();
+  </script>
 </body>
 </html>

--- a/views/wait.ejs
+++ b/views/wait.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Generando imágenes</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <header class="bg-yellow-400">
+    <div class="max-w-2xl mx-auto p-4">
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
+    </div>
+  </header>
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow text-center space-y-4">
+    <h2 class="text-xl font-semibold">Generando imágenes, por favor espera...</h2>
+    <p>Cuando estén listas serás redirigido automáticamente.</p>
+  </main>
+  <script>
+    async function checkStatus() {
+      const res = await fetch('/status');
+      const data = await res.json();
+      if (data.state === 'playing') {
+        window.location.href = '/play';
+      } else {
+        setTimeout(checkStatus, 2000);
+      }
+    }
+    checkStatus();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `state` field in game data
- add wait screen and status endpoint
- redirect lobby users to wait and play screens when rounds start
- run image generation async and clear combinations each round
- auto-poll lobby and wait screens for state changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a0a1bb508331b179432c6f62d84b