### PR TITLE
Adjust scoreboard to show players with partial scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ base64, por lo que no es necesario especificar `response_format`.
 En la página principal puedes crear una nueva partida. Los participantes se unen subiendo su foto. El organizador inicia la ronda y se generarán imágenes combinadas. Después de adivinar se muestran los puntajes.
 
 
-Cada dispositivo usa una sesión y puede registrar varios jugadores. Los puntajes se agrupan por sesión en la tabla final.
+Cada dispositivo usa una sesión y puede registrar varios jugadores. El tablero final muestra un listado por jugador junto a su sesión y los puntos reflejan cada cara acertada, incluso si fueron aciertos parciales.
 
 Este proyecto es solo un MVP y almacena todo en memoria.
 

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -17,22 +17,14 @@
     <table class="w-full table-auto mb-4 border-collapse">
        <thead class="bg-gray-200">
          <tr>
-           <th class="px-2 py-1 text-left">Sesión</th>
-           <th class="px-2 py-1 text-left">Jugadores (puntos)</th>
-           <th class="px-2 py-1 text-left">Puntos totales</th>
+           <th class="px-2 py-1 text-left">Jugador (sesión)</th>
+           <th class="px-2 py-1 text-left">Puntos</th>
          </tr>
        </thead>
-      <% sessions.forEach(s => { %>
+      <% players.forEach(p => { %>
         <tr class="border-t">
-          <td class="py-1"><%= s.sessionId %></td>
-          <td class="py-1">
-            <ul>
-              <% s.players.forEach(pl => { %>
-                <li><%= pl.name %> (<%= pl.points %>)</li>
-              <% }) %>
-            </ul>
-          </td>
-          <td class="py-1 font-semibold"><%= s.points %></td>
+          <td class="py-1"><%= p.name %> (<%= p.sessionId %>)</td>
+          <td class="py-1 font-semibold"><%= p.points %></td>
         </tr>
       <% }) %>
     </table>


### PR DESCRIPTION
## Summary
- award points individually for correct guesses, even if not all faces are selected
- render scoreboard per player and sort by points
- document new scoreboard behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a199ce31c833193dad1cebba59369