### PR TITLE
Allow custom image blend prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ base64, por lo que no es necesario especificar `response_format`.
 
 En la página principal puedes crear una nueva partida. Los participantes se unen subiendo su foto. El organizador inicia la ronda y se generarán imágenes combinadas. Después de adivinar se muestran los puntajes.
 
+En el lobby puedes editar el *prompt* que define cómo se combinarán las fotos. Esto permite personalizar la descripción que se envía al modelo de generación de imágenes.
+
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. Los puntajes se agrupan por sesión en la tabla final.
 

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ app.use(
 let game = {
   round: 1,
   difficulty: 2,
+  prompt: 'Analyze these participant photos and create one new face that blends all of them together.',
   participants: [], // {id, name, photoPath, points, sessionId}
   combinations: [], // {imagePath, participantIds}
   state: 'lobby' // lobby | generating | playing | scoreboard
@@ -38,6 +39,7 @@ let game = {
 function resetGame() {
   game.round = 1;
   game.difficulty = 2;
+  game.prompt = 'Analyze these participant photos and create one new face that blends all of them together.';
   game.participants = [];
   game.combinations = [];
   game.state = 'lobby';
@@ -108,6 +110,9 @@ app.post('/start', async (req, res) => {
   if (game.participants.length < game.difficulty) {
     return res.status(400).send('Not enough participants');
   }
+  game.prompt = req.body.prompt && req.body.prompt.trim() !== ''
+    ? req.body.prompt.trim()
+    : game.prompt;
   game.combinations = [];
   fs.rmSync(path.join(__dirname, 'combinations'), { recursive: true, force: true });
   fs.mkdirSync(path.join(__dirname, 'combinations'), { recursive: true });
@@ -142,7 +147,7 @@ app.post('/start', async (req, res) => {
         }));
         userContent.push({
           type: 'text',
-          text: 'Analyze these participant photos and create one new face that blends all of them together.'
+          text: game.prompt
         });
 
         const chat = await openai.chat.completions.create({

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -24,7 +24,11 @@
       <% }) %>
     </div>
     <a href="/join" class="text-blue-600 underline">Unirse</a>
-    <form action="/start" method="post" class="mt-6">
+    <form action="/start" method="post" class="mt-6 space-y-4">
+      <div>
+        <label class="block mb-1">Prompt de combinación:</label>
+        <textarea name="prompt" rows="2" class="w-full border rounded p-2"><%= game.prompt %></textarea>
+      </div>
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Comenzar ronda</button>
     </form>
   </main>


### PR DESCRIPTION
## Summary
- add `prompt` to in-memory game state and reset it when creating a game
- update `/start` route to read custom prompt
- expose prompt text area in the lobby
- document prompt customization in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a19d6204883319d03da0e53af8353