### PR TITLE
Serve unique combos per player

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ En la página principal puedes crear una nueva partida. Los participantes se une
 
 En el lobby puedes editar el *prompt* que define cómo se combinarán las fotos. Esto permite personalizar la descripción que se envía al modelo de generación de imágenes.
 
+En cada ronda se crea una única imagen por jugador. La dificultad indica cuántos rostros se mezclarán en esa foto, por lo que cada participante sólo debe adivinar una imagen diferente en su dispositivo.
+
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. El tablero final muestra un listado por jugador junto a su sesión y los puntos reflejan cada cara acertada, incluso si fueron aciertos parciales.
 

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -15,13 +15,13 @@
   <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
     <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
     <form action="/guess" method="post" class="space-y-6">
-      <% game.combinations.forEach((c, idx) => { %>
+      <% combos.forEach(c => { %>
         <div class="combo space-y-2">
           <img src="/<%= c.imagePath.split('/').slice(-2).join('/') %>" alt="combo" class="w-48 rounded">
           <div class="options space-x-4">
             <% game.participants.forEach(p => { %>
               <label class="inline-flex items-center">
-                <input type="checkbox" name="combo_<%= idx %>" value="<%= p.id %>" class="mr-1">
+                <input type="checkbox" name="combo_<%= c.index %>" value="<%= p.id %>" class="mr-1">
                 <span><%= p.name %></span>
               </label>
             <% }) %>


### PR DESCRIPTION
## Summary
- generate one combo per player instead of grouping them
- filter `/play` so each session only sees its combos
- document the new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a1db341b08331a2d4eee1145faeee