### PR TITLE
Limit per-image guesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ En la página principal puedes crear una nueva partida. Los participantes se une
 
 En el lobby puedes editar el *prompt* que define cómo se combinarán las fotos. Esto permite personalizar la descripción que se envía al modelo de generación de imágenes.
 
-En cada ronda se crea una única imagen por jugador. La dificultad indica cuántos rostros se mezclarán en esa foto, por lo que cada participante sólo debe adivinar una imagen diferente en su dispositivo.
+En cada ronda se crea una única imagen por jugador. La dificultad indica cuántos rostros se mezclarán en esa foto, por lo que cada participante sólo debe adivinar una imagen diferente en su dispositivo. Al adivinar, cada jugador puede seleccionar hasta esa misma cantidad de nombres por foto.
 
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. El tablero final muestra un listado por jugador junto a su sesión y los puntos reflejan cada cara acertada, incluso si fueron aciertos parciales.

--- a/server.js
+++ b/server.js
@@ -241,7 +241,7 @@ app.post('/guess', (req, res) => {
   for (const [key, value] of Object.entries(guesses)) {
     const index = parseInt(key.split('_')[1]);
     const guessedIds = Array.isArray(value)
-      ? value.map(v => parseInt(v))
+      ? value.map(v => parseInt(v)).slice(0, game.difficulty)
       : [parseInt(value)];
     const combo = game.combinations[index];
     const correctIds = combo.participantIds;

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -12,9 +12,9 @@
       <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
     </div>
   </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-    <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
-    <form action="/guess" method="post" class="space-y-6">
+    <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+      <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
+      <form action="/guess" method="post" class="space-y-6" id="guess-form">
       <% combos.forEach(c => { %>
         <div class="combo space-y-2">
           <img src="/<%= c.imagePath.split('/').slice(-2).join('/') %>" alt="combo" class="w-48 rounded">
@@ -32,5 +32,24 @@
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Enviar respuestas</button>
     </form>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const limit = <%= game.difficulty %>;
+      document.querySelectorAll('.combo').forEach(comboEl => {
+        const boxes = comboEl.querySelectorAll('input[type="checkbox"]');
+        const update = () => {
+          const checked = comboEl.querySelectorAll('input[type="checkbox"]:checked').length;
+          boxes.forEach(box => {
+            if (!box.checked) {
+              box.disabled = checked >= limit;
+            } else {
+              box.disabled = false;
+            }
+          });
+        };
+        boxes.forEach(b => b.addEventListener('change', update));
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- limit posted guesses on the server to the current round difficulty
- restrict number of checkboxes on the play page with JS
- document new rule in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a216dfee08331bb3498bf40664e07