### PR TITLE
Fix scoreboard bug and add reset option

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,6 +66,12 @@ app.post('/create', (req, res) => {
   res.redirect('/lobby');
 });
 
+// Reset and go to home
+app.post('/reset', (req, res) => {
+  resetGame();
+  res.redirect('/');
+});
+
 // Lobby page
 app.get('/lobby', (req, res) => {
   if (game.state === 'generating') return res.redirect('/wait');
@@ -265,7 +271,9 @@ app.post('/guess', (req, res) => {
 
 // Scoreboard
 app.get('/scoreboard', (req, res) => {
-  game.state = 'scoreboard';
+  if (game.state !== 'scoreboard') {
+    return res.redirect('/lobby');
+  }
   const players = game.participants
     .map(p => ({ id: p.id, name: p.name, sessionId: p.sessionId, points: p.points }))
     .sort((a, b) => b.points - a.points);

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -47,6 +47,9 @@
     <form action="/next" method="post" class="mt-4">
       <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Siguiente ronda</button>
     </form>
+    <form action="/reset" method="post" class="mt-2">
+      <button type="submit" class="px-4 py-2 bg-red-500 text-white font-semibold rounded hover:bg-red-600">Reiniciar juego</button>
+    </form>
     <a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- fix scoreboard state bug by redirecting to lobby if not in scoreboard state
- add `/reset` endpoint to start a new game quickly
- add "Reiniciar juego" button on scoreboard page

## Testing
- `npm test`
- `OPENAI_API_KEY=dummy npm start` *(fails: server started)*

------
https://chatgpt.com/codex/tasks/task_e_684a22b769e08331a157d5aa755b6653