### PR TITLE
Refactor views with layout and modern styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
+        "express-ejs-layouts": "^2.5.1",
         "express-fileupload": "^1.5.1",
         "express-session": "^1.18.1",
         "openai": "^5.2.0"
@@ -292,6 +293,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-ejs-layouts": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/express-ejs-layouts/-/express-ejs-layouts-2.5.1.tgz",
+      "integrity": "sha512-IXROv9n3xKga7FowT06n1Qn927JR8ZWDn5Dc9CJQoiiaaDqbhW5PDmWShzbpAa2wjWT1vJqaIM1S6vJwwX11gA=="
     },
     "node_modules/express-fileupload": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
+    "express-ejs-layouts": "^2.5.1",
     "express-fileupload": "^1.5.1",
     "express-session": "^1.18.1",
     "openai": "^5.2.0"

--- a/public/style.css
+++ b/public/style.css
@@ -4,6 +4,6 @@ body {
   background-color: #f3f4f6;
 }
 
-header.bg-yellow-400 {
-  background: linear-gradient(90deg,#f9d342,#f6ad55);
+header.bg-brand {
+  background: linear-gradient(90deg,#06b6d4,#3b82f6);
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const expressLayouts = require('express-ejs-layouts');
 const fileUpload = require('express-fileupload');
 const path = require('path');
 const fs = require('fs');
@@ -12,6 +13,8 @@ const PORT = process.env.PORT || 3000;
 
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
+app.use(expressLayouts);
+app.set('layout', 'layout');
 app.use(express.static(path.join(__dirname, 'public')));
 // Serve uploaded images and generated combinations
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,24 +1,7 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Mezcla Caritas</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
-    </div>
-  </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-    <form action="/create" method="post" class="mb-4">
-      <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Crear nueva partida</button>
-    </form>
-    <% if (game.participants.length > 0) { %>
-      <a href="/lobby" class="text-blue-600 underline">Ir al lobby existente</a>
-    <% } %>
-  </main>
-</body>
-</html>
+<% var title = 'Inicio'; %>
+<form action="/create" method="post" class="mb-4">
+  <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Crear nueva partida</button>
+</form>
+<% if (game.participants.length > 0) { %>
+  <a href="/lobby" class="text-blue-600 underline">Ir al lobby existente</a>
+<% } %>

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Unirse</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
-    </div>
-  </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-    <h2 class="text-xl font-semibold mb-4">Unirse a la partida</h2>
+<% var title = 'Unirse'; %>
+<h2 class="text-xl font-semibold mb-4">Unirse a la partida</h2>
     <form action="/join" method="post" enctype="multipart/form-data" class="space-y-4">
       <div>
         <label class="block mb-1">Nombre:</label>
@@ -24,7 +10,7 @@
         <input id="photoInput" type="file" name="photo" accept="image/*" required class="w-full" />
       </div>
       <img id="preview" class="w-32 h-32 object-cover rounded-full hidden" />
-      <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Enviar</button>
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Enviar</button>
     </form>
     <script>
       const input = document.getElementById('photoInput');
@@ -40,6 +26,3 @@
         reader.readAsDataURL(file);
       });
     </script>
-  </main>
-</body>
-</html>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title><%= typeof title !== 'undefined' ? title + ' - ' : '' %>Mezcla Caritas</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <header class="bg-brand">
+    <div class="max-w-2xl mx-auto p-4">
+      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
+    </div>
+  </header>
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+    <%- body %>
+  </main>
+</body>
+</html>

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -1,38 +1,23 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Lobby</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
+<% var title = 'Lobby'; %>
+<h2 class="text-xl font-semibold mb-4">Lobby - Ronda <%= game.round %> (Dificultad: <%= game.difficulty %>)</h2>
+<p class="mb-2">Participantes inscritos: <%= game.participants.length %></p>
+<div class="grid grid-cols-3 gap-4 mb-4">
+  <% game.participants.forEach(p => { %>
+    <div class="flex flex-col items-center text-center">
+      <img src="/<%= p.photoPath.split('/').slice(-3).join('/') %>" alt="<%= p.name %>" class="w-16 h-16 object-cover rounded-full mb-1">
+      <span class="text-sm"><%= p.name %></span>
     </div>
-  </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-    <h2 class="text-xl font-semibold mb-4">Lobby - Ronda <%= game.round %> (Dificultad: <%= game.difficulty %>)</h2>
-    <p class="mb-2">Participantes inscritos: <%= game.participants.length %></p>
-    <div class="grid grid-cols-3 gap-4 mb-4">
-      <% game.participants.forEach(p => { %>
-        <div class="flex flex-col items-center text-center">
-          <img src="/<%= p.photoPath.split('/').slice(-3).join('/') %>" alt="<%= p.name %>" class="w-16 h-16 object-cover rounded-full mb-1">
-          <span class="text-sm"><%= p.name %></span>
-        </div>
-      <% }) %>
-    </div>
-    <a href="/join" class="text-blue-600 underline">Unirse</a>
-    <form action="/start" method="post" class="mt-6 space-y-4">
-      <div>
-        <label class="block mb-1">Prompt de combinación:</label>
-        <textarea name="prompt" rows="2" class="w-full border rounded p-2"><%= game.prompt %></textarea>
-      </div>
-      <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Comenzar ronda</button>
-    </form>
-  </main>
-  <script>
+  <% }) %>
+</div>
+<a href="/join" class="text-blue-600 underline">Unirse</a>
+<form action="/start" method="post" class="mt-6 space-y-4">
+  <div>
+    <label class="block mb-1">Prompt de combinación:</label>
+    <textarea name="prompt" rows="2" class="w-full border rounded p-2"><%= game.prompt %></textarea>
+  </div>
+  <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Comenzar ronda</button>
+</form>
+<script>
     async function poll() {
       const res = await fetch('/status');
       const data = await res.json();
@@ -45,6 +30,4 @@
       }
     }
     poll();
-  </script>
-</body>
-</html>
+</script>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Jugar</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
-    </div>
-  </header>
-    <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-      <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
+<% var title = 'Jugar'; %>
+<h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
       <form action="/guess" method="post" class="space-y-6" id="guess-form">
       <% combos.forEach(c => { %>
         <div class="combo space-y-2">
@@ -29,10 +15,9 @@
         </div>
         <hr class="my-4">
       <% }) %>
-      <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Enviar respuestas</button>
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Enviar respuestas</button>
     </form>
-  </main>
-  <script>
+<script>
     document.addEventListener('DOMContentLoaded', () => {
       const limit = <%= game.difficulty %>;
       document.querySelectorAll('.combo').forEach(comboEl => {
@@ -50,6 +35,4 @@
         boxes.forEach(b => b.addEventListener('change', update));
       });
     });
-  </script>
-</body>
-</html>
+</script>

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -1,21 +1,8 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Tabla de posiciones</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
-    </div>
-  </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
-    <h2 class="text-xl font-semibold mb-4">Tabla de posiciones - Ronda <%= game.round %></h2>
-    <table class="w-full table-auto mb-4 border-collapse">
-      <thead class="bg-gray-200">
+<% var title = 'Tabla de posiciones'; %>
+<h2 class="text-xl font-semibold mb-4">Tabla de posiciones - Ronda <%= game.round %></h2>
+<div class="overflow-x-auto">
+  <table class="min-w-full table-auto mb-4 border-collapse divide-y divide-gray-200">
+    <thead class="bg-gray-100">
         <tr>
           <th class="px-2 py-1 text-left">Jugador (sesión)</th>
           <th class="px-2 py-1 text-left">Puntos</th>
@@ -25,17 +12,17 @@
         </tr>
       </thead>
       <% players.forEach(p => { %>
-        <tr class="border-t">
-          <td class="py-1"><%= p.name %> (<%= p.sessionId %>)</td>
-          <td class="py-1 font-semibold"><%= p.points %></td>
+        <tr class="border-t divide-x divide-gray-200">
+          <td class="py-1 px-2"><%= p.name %> (<%= p.sessionId %>)</td>
+          <td class="py-1 px-2 font-semibold"><%= p.points %></td>
           <% game.combinations.forEach((c, idx) => { %>
             <% const res = roundResults[p.id] && roundResults[p.id][idx]; %>
-            <td class="py-1 text-center">
+            <td class="py-1 px-2 text-center">
               <% if (res && res.correct) { %>
-                ✓
+                <span class="text-green-600 font-bold">✓</span>
               <% } else if (res) { %>
                 <% const names = res.correctIds.map(id => game.participants.find(pr => pr.id === id).name).join(', '); %>
-                ✗ (<%= names %>)
+                <span class="text-red-600" title="<%= names %>">✗</span>
               <% } else { %>
                 -
               <% } %>
@@ -43,14 +30,12 @@
           <% }) %>
         </tr>
       <% }) %>
-    </table>
-    <form action="/next" method="post" class="mt-4">
-      <button type="submit" class="px-4 py-2 bg-yellow-500 text-white font-semibold rounded hover:bg-yellow-600">Siguiente ronda</button>
-    </form>
-    <form action="/reset" method="post" class="mt-2">
-      <button type="submit" class="px-4 py-2 bg-red-500 text-white font-semibold rounded hover:bg-red-600">Reiniciar juego</button>
-    </form>
-    <a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>
-  </main>
-</body>
-</html>
+  </table>
+</div>
+<form action="/next" method="post" class="mt-4">
+  <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Siguiente ronda</button>
+</form>
+<form action="/reset" method="post" class="mt-2">
+  <button type="submit" class="px-4 py-2 bg-red-500 text-white font-semibold rounded hover:bg-red-600">Reiniciar juego</button>
+</form>
+<a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>

--- a/views/wait.ejs
+++ b/views/wait.ejs
@@ -1,22 +1,9 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Generando imágenes</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/style.css" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <header class="bg-yellow-400">
-    <div class="max-w-2xl mx-auto p-4">
-      <h1 class="text-2xl font-bold text-gray-800">Mezcla Caritas</h1>
-    </div>
-  </header>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow text-center space-y-4">
-    <h2 class="text-xl font-semibold">Generando imágenes, por favor espera...</h2>
-    <p>Cuando estén listas serás redirigido automáticamente.</p>
-  </main>
-  <script>
+<% var title = 'Generando imágenes'; %>
+<div class="text-center space-y-4">
+  <h2 class="text-xl font-semibold">Generando imágenes, por favor espera...</h2>
+  <p>Cuando estén listas serás redirigido automáticamente.</p>
+</div>
+<script>
     async function checkStatus() {
       const res = await fetch('/status');
       const data = await res.json();
@@ -27,6 +14,4 @@
       }
     }
     checkStatus();
-  </script>
-</body>
-</html>
+</script>


### PR DESCRIPTION
## Summary
- add express-ejs-layouts and create `views/layout.ejs`
- update Tailwind styles to use a blue gradient header
- apply new layout across all views
- redesign scoreboard table with responsive styling and success/fail icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a231863d4833196ce55c2b5f304bd