### PR TITLE
Fix sticky footer layout

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
     <form action="/create" method="post" class="mb-4">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Crear nueva partida</button>
     </form>

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
     <h2 class="text-xl font-semibold mb-4">Unirse a la partida</h2>
     <form action="/join" method="post" enctype="multipart/form-data" class="space-y-4">
       <div>

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
     <h2 class="text-xl font-semibold mb-4">Lobby - Ronda <%= game.round %> (Dificultad: <%= game.difficulty %>)</h2>
     <p class="mb-2">Participantes inscritos: <%= game.participants.length %></p>
     <div class="grid grid-cols-3 gap-4 mb-4">

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="bg-gray-100 text-gray-800">
+<body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-    <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+    <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
       <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
       <form action="/guess" method="post" class="space-y-6" id="guess-form">
       <% combos.forEach(c => { %>

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="bg-gray-100 text-gray-800">
+<body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow">
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
     <h2 class="text-xl font-semibold mb-4">Tabla de posiciones - Ronda <%= game.round %></h2>
     <table class="w-full table-auto mb-4 border-collapse">
       <thead class="bg-gray-200">

--- a/views/wait.ejs
+++ b/views/wait.ejs
@@ -6,9 +6,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css" />
 </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow text-center space-y-4">
+  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow text-center space-y-4 flex-grow">
     <h2 class="text-xl font-semibold">Generando imágenes, por favor espera...</h2>
     <div class="flex justify-center">
       <svg class="animate-spin h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- keep footer at bottom of the viewport by using flex layout on every page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a2b81517c8331a1d637c2cc5e9fcd