### PR TITLE
Improve session handling for active rounds

### DIFF
--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -35,8 +35,10 @@
       const data = await res.json();
       if (data.state === 'generating') {
         window.location.href = '/wait';
-      } else if (data.state === 'playing') {
+      } else if (data.state === 'playing' && data.joined) {
         window.location.href = '/play';
+      } else if (data.state === 'scoreboard' && data.joined) {
+        window.location.href = '/scoreboard';
       } else {
         setTimeout(poll, 2000);
       }

--- a/views/wait.ejs
+++ b/views/wait.ejs
@@ -34,8 +34,10 @@
         const pct = Math.round((data.generated / data.total) * 100);
         document.getElementById('progress').textContent = `Progreso: ${data.generated}/${data.total} (${pct}%)`;
       }
-      if (data.state === 'playing') {
+      if (data.state === 'playing' && data.joined) {
         window.location.href = '/play';
+      } else if (data.state === 'playing') {
+        window.location.href = '/lobby';
       } else if (data.state === 'lobby') {
         window.location.href = '/lobby';
       } else {


### PR DESCRIPTION
## Summary
- add `isJoined` helper to check if a session belongs to current participants
- keep unregistered visitors in the lobby during active rounds
- expose session status via `/status`
- redirect only registered players to play or scoreboard
- adjust client polling logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a2c181bcc8331bc698ac6311b1ca3