### PR TITLE
Fix scoreboard sync

### DIFF
--- a/server.js
+++ b/server.js
@@ -309,6 +309,9 @@ app.get('/scoreboard', (req, res) => {
 
 // Next round
 app.post('/next', (req, res) => {
+  if (game.state !== 'scoreboard') {
+    return res.redirect('/lobby');
+  }
   game.round += 1;
   game.difficulty += 1;
   game.combinations = [];

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -49,6 +49,24 @@
   <a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>
   </main>
   <%- include('partials/footer') %>
+  <script>
+    async function poll() {
+      const res = await fetch('/status');
+      const data = await res.json();
+      if (data.state === 'generating') {
+        window.location.href = '/wait';
+      } else if (data.state === 'playing' && data.joined) {
+        window.location.href = '/play';
+      } else if (data.state === 'lobby') {
+        window.location.href = '/lobby';
+      } else if (data.state !== 'scoreboard') {
+        window.location.href = '/lobby';
+      } else {
+        setTimeout(poll, 2000);
+      }
+    }
+    poll();
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- redirect scoreboard users when game state changes
- guard /next endpoint to avoid multiple round skips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a2d97aae88331bb610ba05f62c21b