### PR TITLE
Add themed background on special names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ En el lobby puedes editar el *prompt* que define cómo se combinarán las fotos.
 
 En cada ronda se crea una única imagen por jugador. La dificultad indica cuántos rostros se mezclarán en esa foto, por lo que cada participante sólo debe adivinar una imagen diferente en su dispositivo. Al adivinar, cada jugador puede seleccionar hasta esa misma cantidad de nombres por foto.
 
+También se crea un fondo a partir de la foto de un participante elegido al azar. Si esa persona se registró como Licha, Lisandro o Lisan, la imagen utiliza una temática de Breaking Bad o Red Dead Redemption.
+
 
 Cada dispositivo usa una sesión y puede registrar varios jugadores. El tablero final muestra un listado por jugador junto a su sesión y los puntos reflejan cada cara acertada, incluso si fueron aciertos parciales.
 

--- a/server.js
+++ b/server.js
@@ -165,9 +165,15 @@ app.post('/start', async (req, res) => {
       const bgPlayer = game.participants[Math.floor(Math.random() * game.participants.length)];
       try {
         const img = await fs.promises.readFile(bgPlayer.photoPath, { encoding: 'base64' });
+        const specials = ['licha', 'lisandro', 'lisan'];
+        const isSpecial = specials.includes(bgPlayer.name.trim().toLowerCase());
+        const theme = Math.random() < 0.5 ? 'Breaking Bad' : 'Red Dead Redemption';
+        const bgText = isSpecial
+          ? `Create a full body image of this person in the style of ${theme}.`
+          : 'Create a funny full body image of this person in a weird situation and place.';
         const bgContent = [
           { type: 'image_url', image_url: { url: `data:image/png;base64,${img}` } },
-          { type: 'text', text: 'Create a funny full body image of this person in a weird situation and place.' }
+          { type: 'text', text: bgText }
         ];
         const bgChat = await openai.chat.completions.create({
           model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- create background with Breaking Bad or Red Dead Redemption theme when the selected participant is named Licha, Lisandro or Lisan
- document the new special-case background generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a310d42388331a7ad4fb7ece8b4f3