### PR TITLE
Adjust layout for background and pages

### DIFF
--- a/views/partials/background.ejs
+++ b/views/partials/background.ejs
@@ -7,7 +7,7 @@
     content: '';
     position: fixed;
     inset: 0;
-    background: url('/<%= game.background.split('/').slice(-2).join('/') %>') center/contain no-repeat;
+    background: url('/<%= game.background.split('/').slice(-2).join('/') %>') right center/contain no-repeat;
     opacity: 0.15;
     filter: brightness(1.2);
     pointer-events: none;

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-    <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
+    <main class="max-w-2xl ml-6 p-6 bg-white mt-6 rounded shadow flex-grow">
       <h2 class="text-xl font-semibold mb-4">Selecciona las caras que aparecen</h2>
       <form action="/guess" method="post" class="space-y-6" id="guess-form">
       <% combos.forEach(c => { %>

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow flex-grow">
+  <main class="max-w-2xl ml-6 p-6 bg-white mt-6 rounded shadow flex-grow">
     <h2 class="text-xl font-semibold mb-4">Tabla de posiciones - Ronda <%= game.round %></h2>
     <table class="w-full table-auto mb-4 border-collapse">
       <thead class="bg-gray-200">

--- a/views/wait.ejs
+++ b/views/wait.ejs
@@ -9,7 +9,7 @@
 </head>
   <body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
   <%- include('partials/header') %>
-  <main class="max-w-2xl mx-auto p-6 bg-white mt-6 rounded shadow text-center space-y-4 flex-grow">
+  <main class="max-w-2xl ml-6 p-6 bg-white mt-6 rounded shadow text-center space-y-4 flex-grow">
     <h2 class="text-xl font-semibold">Generando imágenes, por favor espera...</h2>
     <div class="flex justify-center">
       <svg class="animate-spin h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- align generated background image to the right side
- move the wait, play and scoreboard interfaces to the left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a33d069bc8331bf6d0ee672d7fb60