### PR TITLE
Enhance scoreboard results

### DIFF
--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -28,11 +28,12 @@
           <% game.combinations.forEach((c, idx) => { %>
             <% const res = roundResults[p.id] && roundResults[p.id][idx]; %>
             <td class="py-1 text-center">
-              <% if (res && res.correct) { %>
-                ✓
-              <% } else if (res) { %>
-                <% const names = res.correctIds.map(id => game.participants.find(pr => pr.id === id).name).join(', '); %>
-                ✗ (<%= names %>)
+              <% if (res) { %>
+                <%= res.correct ? '✓' : '✗' %>
+                <% res.guessedIds.forEach((gid, i) => { %>
+                  <% const name = game.participants.find(pr => pr.id === gid).name; %>
+                  <span class="<%= res.correctIds.includes(gid) ? 'text-green-600' : 'text-red-600' %>"><%= name %></span><%= i < res.guessedIds.length - 1 ? ', ' : '' %>
+                <% }) %>
               <% } else { %>
                 -
               <% } %>


### PR DESCRIPTION
## Summary
- color correct guesses in green and incorrect guesses in red
- show guessed names for each image in the scoreboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685329629ad08331af0a091f8f1e4ea1