### PR TITLE
Add caption overlay for background images

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,9 @@ let game = {
   roundResults: {}, // {playerId: [{guessedIds, correctIds, correct}]}
   state: 'lobby', // lobby | generating | playing | scoreboard
   totalToGenerate: 0,
-  background: null
+  background: null,
+  backgroundTitle: null,
+  backgroundOwner: null
 };
 
 function isJoined(req) {
@@ -55,6 +57,8 @@ function resetGame() {
   game.state = 'lobby';
   game.totalToGenerate = 0;
   game.background = null;
+  game.backgroundTitle = null;
+  game.backgroundOwner = null;
   // Clean uploads and combinations directories
   fs.rmSync(path.join(__dirname, 'uploads'), { recursive: true, force: true });
   fs.rmSync(path.join(__dirname, 'combinations'), { recursive: true, force: true });
@@ -214,9 +218,13 @@ app.post('/start', async (req, res) => {
         const bgPath = path.join(__dirname, 'backgrounds', `bg_round_${game.round}.png`);
         await fs.promises.writeFile(bgPath, bgBuffer);
         game.background = bgPath;
+        game.backgroundTitle = bgParams.prompt;
+        game.backgroundOwner = bgPlayer.name;
       } catch (bgErr) {
         console.error('Error generating background image', bgErr);
         game.background = null;
+        game.backgroundTitle = null;
+        game.backgroundOwner = null;
       }
       const ids = game.participants.map(p => p.id);
       // shuffle participants for fair combinations
@@ -375,6 +383,8 @@ app.post('/next', (req, res) => {
   game.combinations = [];
   game.roundResults = {};
   game.background = null;
+  game.backgroundTitle = null;
+  game.backgroundOwner = null;
   game.state = 'lobby';
   res.redirect('/lobby');
 });

--- a/views/partials/background.ejs
+++ b/views/partials/background.ejs
@@ -13,6 +13,20 @@
     pointer-events: none;
     z-index: -1;
   }
+  body::after {
+    content: '<%= ((game.backgroundOwner ? game.backgroundOwner + " - " : "") + (game.backgroundTitle || "Nico siendo perseguido por una viejita en Manhattan")).replace(/'/g, "\\'") %>';
+    position: fixed;
+    top: 0.5rem;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 1.25rem;
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.9);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+    pointer-events: none;
+    z-index: -1;
+  }
 </style>
 <% } %>
 


### PR DESCRIPTION
## Summary
- store background image owner name
- include owner name with background prompt overlay
- reset stored owner between rounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68534723372c8331abdd17cf13b4ed5f