### PR TITLE
Prevent new session reset

### DIFF
--- a/server.js
+++ b/server.js
@@ -77,6 +77,9 @@ app.get('/', (req, res) => {
 
 // Create new game (organizer)
 app.post('/create', (req, res) => {
+  if (game.participants.length > 0 || game.state !== 'lobby') {
+    return res.redirect('/lobby');
+  }
   resetGame();
   game.state = 'lobby';
   res.redirect('/lobby');


### PR DESCRIPTION
## Summary
- ensure POST `/create` doesn't reset an active game and redirects to the current lobby

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534966b05883318734b059ed2bf3b5