### PR TITLE
Restrict multiple joins per session

### DIFF
--- a/server.js
+++ b/server.js
@@ -125,6 +125,7 @@ app.get('/lobby', (req, res) => {
 
 // Join page
 app.get('/join', (req, res) => {
+  if (isJoined(req)) return res.redirect('/lobby');
   res.render('join', { game });
 });
 
@@ -156,6 +157,9 @@ app.get('/participants', (req, res) => {
 
 // Handle join
 app.post('/join', async (req, res) => {
+  if (isJoined(req)) {
+    return res.redirect('/lobby');
+  }
   const name = req.body.name;
   if (!req.files || !req.files.photo || !name) {
     return res.status(400).send('Name and photo required');


### PR DESCRIPTION
## Summary
- restrict access to the join page when already joined
- prevent posting to `/join` multiple times
- `npm test` was run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685353ad55fc83319742863848204fe7