### PR TITLE
Fix scoreboard wait

### DIFF
--- a/server.js
+++ b/server.js
@@ -416,14 +416,18 @@ app.post('/guess', (req, res) => {
     });
   }
 
-  game.state = 'scoreboard';
+  if (allGuessed()) {
+    game.state = 'scoreboard';
+  }
   logEvent('Guesses submitted for round', game.round);
   res.redirect('/scoreboard');
 });
 
 // Scoreboard
 app.get('/scoreboard', (req, res) => {
-  if (game.state !== 'scoreboard') {
+  const sessionPlayerIds = req.session.playerIds || [];
+  const guessed = sessionPlayerIds.some(pid => game.roundResults[pid]);
+  if (game.state !== 'scoreboard' && !guessed) {
     return res.redirect('/lobby');
   }
   if (!isJoined(req) && req.sessionID !== game.owner) {
@@ -438,7 +442,8 @@ app.get('/scoreboard', (req, res) => {
     players,
     roundResults: game.roundResults,
     everyoneGuessed,
-    sessionID: req.sessionID
+    sessionID: req.sessionID,
+    hasGuessed: guessed
   });
 });
 

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -80,8 +80,12 @@
       const data = await res.json();
       if (data.state === 'generating') {
         window.location.href = '/wait';
-      } else if (data.state === 'playing' && data.joined) {
-        window.location.href = '/play';
+      } else if (data.state === 'playing') {
+        if (data.joined && <%= !hasGuessed %>) {
+          window.location.href = '/play';
+        } else {
+          setTimeout(poll, 2000);
+        }
       } else if (data.state === 'lobby') {
         window.location.href = '/lobby';
       } else if (data.state !== 'scoreboard') {


### PR DESCRIPTION
## Summary
- ensure round stays in play mode until everyone guessed
- let players who already guessed view the scoreboard while others guess
- keep scoreboard screen stable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0e05a7c08331abfce97879d309c0