### PR TITLE
Fix unauthorized round start

### DIFF
--- a/server.js
+++ b/server.js
@@ -106,6 +106,9 @@ app.post('/create', (req, res) => {
 
 // Reset and go to home
 app.post('/reset', (req, res) => {
+  if (req.sessionID !== game.owner) {
+    return res.status(403).send('Only the organizer can reset the game');
+  }
   resetGame();
   logEvent('Game reset by', req.sessionID);
   req.session.playerIds = [];
@@ -120,7 +123,7 @@ app.get('/lobby', (req, res) => {
   } else if (game.state === 'scoreboard') {
     if (isJoined(req)) return res.redirect('/scoreboard');
   }
-  res.render('lobby', { game });
+  res.render('lobby', { game, sessionID: req.sessionID });
 });
 
 // Join page
@@ -179,6 +182,12 @@ app.post('/join', async (req, res) => {
 
 // Start round
 app.post('/start', async (req, res) => {
+  if (game.state !== 'lobby') {
+    return res.status(403).send('Cannot start a round right now');
+  }
+  if (req.sessionID !== game.owner) {
+    return res.status(403).send('Only the organizer can start the round');
+  }
   if (game.participants.length < game.difficulty) {
     return res.status(400).send('Not enough participants');
   }

--- a/views/lobby.ejs
+++ b/views/lobby.ejs
@@ -21,13 +21,15 @@
       <% }) %>
     </div>
     <a href="/join" class="text-blue-600 underline">Unirse</a>
-    <form action="/start" method="post" class="mt-6 space-y-4">
-      <div>
-        <label class="block mb-1">Prompt de combinación:</label>
-        <textarea name="prompt" rows="2" class="w-full border rounded p-2"><%= game.prompt %></textarea>
-      </div>
-      <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Comenzar ronda</button>
-    </form>
+    <% if (sessionID === game.owner) { %>
+      <form action="/start" method="post" class="mt-6 space-y-4">
+        <div>
+          <label class="block mb-1">Prompt de combinación:</label>
+          <textarea name="prompt" rows="2" class="w-full border rounded p-2"><%= game.prompt %></textarea>
+        </div>
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded hover:bg-blue-700">Comenzar ronda</button>
+      </form>
+    <% } %>
   </main>
   <script>
     async function updateParticipants() {

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -54,9 +54,11 @@
       <% } else { %>
         <p class="text-sm text-red-600 mt-4">Aún hay jugadores adivinando</p>
       <% } %>
-      <form action="/reset" method="post" class="mt-2">
-        <button type="submit" class="px-4 py-2 bg-red-500 text-white font-semibold rounded hover:bg-red-600">Reiniciar juego</button>
-      </form>
+      <% if (sessionID === game.owner) { %>
+        <form action="/reset" method="post" class="mt-2">
+          <button type="submit" class="px-4 py-2 bg-red-500 text-white font-semibold rounded hover:bg-red-600">Reiniciar juego</button>
+        </form>
+      <% } %>
       <a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>
     </div>
     <aside class="md:w-1/3 mt-6 md:mt-0">


### PR DESCRIPTION
## Summary
- block /start unless requester owns the game
- block /reset unless requester owns the game
- pass sessionID to lobby and hide start button for others
- hide reset button on scoreboard for non owners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a0e1c18a883319f0883e45c170faf