### PR TITLE
Fix scoreboard image layout

### DIFF
--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -60,8 +60,8 @@
         </form>
       <% } %>
       <a href="/lobby" class="text-blue-600 underline mt-4 inline-block">Volver al lobby</a>
-    </div>
-    <aside class="md:w-1/3 mt-6 md:mt-0">
+      </div>
+      <aside class="md:w-1/3 mt-6 md:mt-0 md:order-first">
       <h3 class="text-lg font-semibold mb-2">Imágenes generadas</h3>
       <% game.combinations.forEach((c) => { %>
         <div class="mb-4">


### PR DESCRIPTION
## Summary
- adjust scoreboard page so the generated images column always comes first
- run `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a10184428833198cf78da18fb15db