### PR TITLE
Show uploaded photo label on scoreboard

### DIFF
--- a/server.js
+++ b/server.js
@@ -171,9 +171,17 @@ app.post('/join', async (req, res) => {
   const sessionId = req.sessionID;
   const sessionDir = path.join(__dirname, 'uploads', sessionId);
   fs.mkdirSync(sessionDir, { recursive: true });
-  const uploadPath = path.join(sessionDir, `${id}_${req.files.photo.name}`);
+  const photoLabel = req.files.photo.name;
+  const uploadPath = path.join(sessionDir, `${id}_${photoLabel}`);
   await req.files.photo.mv(uploadPath);
-  game.participants.push({ id, name, photoPath: uploadPath, points: 0, sessionId });
+  game.participants.push({
+    id,
+    name,
+    photoPath: uploadPath,
+    photoLabel,
+    points: 0,
+    sessionId
+  });
   logEvent('Player joined', name, 'id', id);
   req.session.playerIds = req.session.playerIds || [];
   req.session.playerIds.push(id);
@@ -443,7 +451,13 @@ app.get('/scoreboard', (req, res) => {
     return res.redirect('/lobby');
   }
   const players = game.participants
-    .map(p => ({ id: p.id, name: p.name, sessionId: p.sessionId, points: p.points }))
+    .map(p => ({
+      id: p.id,
+      name: p.name,
+      sessionId: p.sessionId,
+      points: p.points,
+      photoLabel: p.photoLabel || path.basename(p.photoPath).split('_').slice(1).join('_')
+    }))
     .sort((a, b) => b.points - a.points);
   const everyoneGuessed = allGuessed();
   res.render('scoreboard', {

--- a/views/scoreboard.ejs
+++ b/views/scoreboard.ejs
@@ -15,7 +15,7 @@
       <table class="w-full table-auto mb-4 border-collapse">
         <thead class="bg-gray-200">
           <tr>
-            <th class="px-2 py-1 text-left">Jugador (sesión)</th>
+            <th class="px-2 py-1 text-left">Jugador (imagen)</th>
             <th class="px-2 py-1 text-left">Puntos</th>
             <% game.combinations.forEach((c, idx) => { %>
               <th class="px-2 py-1 text-center">Foto <%= idx + 1 %></th>
@@ -24,7 +24,7 @@
         </thead>
         <% players.forEach(p => { %>
           <tr class="border-t">
-            <td class="py-1"><%= p.name %> (<%= p.sessionId %>)</td>
+            <td class="py-1"><%= p.name %> (<%= p.photoLabel %>)</td>
             <td class="py-1 font-semibold"><%= p.points %></td>
             <% game.combinations.forEach((c, idx) => { %>
               <% const res = roundResults[p.id] && roundResults[p.id][idx]; %>


### PR DESCRIPTION
## Summary
- display the uploaded photo label next to each player's name
- keep scoreboard sorted by points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a0ffd9f58833182f370ea684163c3